### PR TITLE
fix: errors when file is in wildignore

### DIFF
--- a/lua/flatten/core.lua
+++ b/lua/flatten/core.lua
@@ -70,7 +70,11 @@ M.edit_files = function(args, response_pipe, guest_cwd, stdin, force_block)
 				argstr = argstr .. " " .. p
 			end
 		end
+		local wildignore = vim.o.wildignore
+		-- Hack to work around https://github.com/vim/vim/issues/4610
+		vim.o.wildignore = ""
 		vim.cmd("0argadd " .. argstr)
+		vim.o.wildignore = wildignore
 	end
 
 	-- Create buffer for stdin pipe input


### PR DESCRIPTION
If a file is in `wildignore`, you'll receive a `E479: No match` from the argadd command. As best I can tell, this is because of https://github.com/vim/vim/issues/4610.
This is a particular problem because my wildignore includes `*/.git/*`