### PR TITLE
fix: prioritize guest cwd

### DIFF
--- a/lua/flatten/core.lua
+++ b/lua/flatten/core.lua
@@ -62,7 +62,7 @@ M.edit_files = function(args, response_pipe, guest_cwd, stdin, force_block)
 	if nargs > 0 then
 		local argstr = ""
 		for i, arg in ipairs(args) do
-			local p = vim.fn.fnameescape(vim.loop.fs_realpath(arg) or (guest_cwd .. "/" .. arg))
+			local p = vim.fn.fnameescape(guest_cwd .. "/" .. arg)
 			args[i] = p
 			if argstr == "" or argstr == nil then
 				argstr = p


### PR DESCRIPTION
Hi @willothy,

Thank you for writing this plugin, it's has improved my workflow in a major way.

I noticed an unexpected behavior related to files from different working directories. When the terminal buffer changes directories, we should be able to open the intended file even if it matches the pathname in the Neovim current working directory.

And even when the resulting path doesn't match any files, it likely means I want to start a new file.

For example, having:

```shell
/tmp/example $ tree .
.
├── a
│   └── README.md
└── b
    └── README.md

2 directories, 2 files

/tmp/example $ cd a
/tmp/example/a $ vim README.md
```

In a terminal buffer:

```shell
/tmp/example/a $ cd ../b
/tmp/example/b $ vim README.md
/tmp/example/b $
```

I would expect `/tmp/example/b/README.md` to load in a new buffer, but I get `/tmp/example/a/README.md` instead.
