### PR TITLE
Read and pass full argv options

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ Flatten comes with the following defaults:
 ```lua
 {
     callbacks = {
+        ---@param argv table a list of all the arguments in the nested session
+        should_block = function(argv)
+          return false
+        end,
         -- Called when a request to edit file(s) is received
         pre_open = function() end,
         -- Called after a file is opened
@@ -105,7 +109,7 @@ Flatten comes with the following defaults:
         -- tab            -> open in new tab
         -- split          -> open in split
         -- vsplit         -> open in vsplit
-        -- func(new_bufs) -> only open the files, allowing you to handle window opening yourself.
+        -- func(new_bufs, argv) -> only open the files, allowing you to handle window opening yourself.
         -- Argument is an array of buffer numbers representing the newly opened files.
         open = "current",
         -- Affects which file gets focused when opening multiple at once
@@ -135,6 +139,13 @@ Here's my setup for toggleterm, including an autocmd to automatically close a gi
             open = "alternate"
         },
         callbacks = {
+            should_block = function(argv)
+                -- In this case, we would block if we find the diff-mode option
+                -- Note that argv contains all the parts of the CLI command, including
+                -- Neovim's path, commands, options and files.
+                -- See: :help v:argv
+                return vim.tbl_contains(argv, "-d")
+            end,
             post_open = function(bufnr, winnr, ft, is_blocking)
                 if is_blocking then
                     -- Hide the terminal while it's blocking

--- a/lua/flatten/guest.lua
+++ b/lua/flatten/guest.lua
@@ -20,20 +20,14 @@ local function send_files(host, files, stdin)
 		cwd = sanitize(cwd)
 	end
 
-	local call = string.format([[
-		return require('flatten.core').edit_files(
-			%s,   -- `args` passed into nested instance.
-			'%s', -- guest default socket.
-			'%s', -- guest global cwd.
-			%s,   -- stdin lines or {}.
-			%s    -- enable blocking
-		)]],
-		vim.inspect(files),
-		server,
-		cwd,
-		vim.inspect(stdin),
-		force_block and 'true' or 'false'
-	)
+	local call = string.format([[return require('flatten.core').edit_files(%s)]], vim.inspect({
+		files = files,
+		response_pipe = server,
+		guest_cwd = cwd,
+		stdin = stdin,
+		argv = vim.v.argv,
+		force_block = force_block,
+	}))
 
 	for _, buf in ipairs(vim.api.nvim_list_bufs()) do
 		vim.api.nvim_buf_delete(buf, { force = true })

--- a/lua/flatten/guest.lua
+++ b/lua/flatten/guest.lua
@@ -11,7 +11,8 @@ end
 local function send_files(host, files, stdin)
 	if #files < 1 and #stdin < 1 then return end
 
-	local force_block = vim.g.flatten_wait ~= nil
+	local config = require("flatten").config
+	local force_block = vim.g.flatten_wait ~= nil or config.callbacks.should_block(vim.v.argv)
 
 	local server = vim.fn.fnameescape(vim.v.servername)
 	local cwd = vim.fn.fnameescape(vim.fn.getcwd( -1, -1))

--- a/lua/flatten/init.lua
+++ b/lua/flatten/init.lua
@@ -2,6 +2,10 @@ local M = {}
 
 M.config = {
 	callbacks = {
+		---@param argv table a list of all the arguments in the nested session
+		should_block = function(argv)
+			return false
+		end,
 		pre_open = function()
 		end,
 		post_open = function(bufnr, winnr, filetype, is_blocking)


### PR DESCRIPTION
Hi @willothy,

This PR is tangentially related to #32.

It provides the ability of reading all the arguments used to open the nested nvim session.

It exposes those params in two ways:

- As the second parameter of the custom `window.open` function, so the user can change the behavior of the new buffers
- Through the new callback `callbacks.should_block`, so the user can define their custom use cases

I decided not to address other cases like `+Man`, since you may already have something in mind for that.

Let me know what you think, I'm open to changes.