### PR TITLE
fix: absolute paths should not use the guest cwd

### DIFF
--- a/lua/flatten/core.lua
+++ b/lua/flatten/core.lua
@@ -78,7 +78,8 @@ M.edit_files = function(opts)
 	if nargs > 0 then
 		local argstr = ""
 		for i, arg in ipairs(files) do
-			local p = vim.fn.fnameescape(guest_cwd .. "/" .. arg)
+			local is_absolute = string.find(arg, "^/")
+			local p = vim.fn.fnameescape(is_absolute and arg or (guest_cwd .. "/" .. arg))
 			files[i] = p
 			if argstr == "" or argstr == nil then
 				argstr = p


### PR DESCRIPTION
This is a follow-up to #30.

Removing the `vim.loop.fs_realpath` check helps with relative paths that exist in the guest, but it breaks absolute paths.

For example, in a neovim terminal

```shell
cd /tmp/
vim /tmp/a/file.txt
```

Would concatenate the path to `/tmp//tmp/a/file.txt`

I'm guessing checking for the real path was supposed to handle that scenario, it just conflicted with relative paths that matched the host cwd.

This commit checks each file to see if it's absolute and avoid prepending the guest cwd.