### PR TITLE
fix: support for pre-0.9 Neovim instances

### DIFF
--- a/lua/flatten/core.lua
+++ b/lua/flatten/core.lua
@@ -81,7 +81,12 @@ M.edit_files = function(opts)
 			if is_cmd then
 				is_cmd = false
 				-- execute --cmd <cmd> commands
-				vim.api.nvim_exec2(arg, {})
+				if vim.api.nvim_exec2 then
+					-- nvim_exec2 only exists in nvim 0.9+
+					vim.api.nvim_exec2(arg, {})
+				else
+					vim.api.nvim_exec(arg, false)
+				end
 			elseif arg:sub(1, 1) == "+" then
 				local cmd = string.sub(arg, 2, -1)
 				table.insert(postcmds, cmd)


### PR DESCRIPTION
The `nvim_exec2` function is part of the [latest Neovim release](https://github.com/neovim/neovim/commit/040f1459849ab05b04f6bb1e77b3def16b4c2f2b).

---

I was giving the command passthrough a whirl and noticed this issue. I'm still on nvim 0.8.