### PR TITLE
fix(setup): default to an empty table when `opt` is not provided

### DIFF
--- a/lua/flatten/init.lua
+++ b/lua/flatten/init.lua
@@ -24,7 +24,7 @@ M.config = {
 }
 
 M.setup = function(opt)
-	M.config = vim.tbl_deep_extend("keep", opt, M.config)
+	M.config = vim.tbl_deep_extend("keep", opt or {}, M.config)
 
 	local pipe_path = os.getenv("NVIM")
 	if pipe_path ~= nil then


### PR DESCRIPTION
This is a common "convention", which is widely used by other plugins.

Fix #43