### PR TITLE
feat: get buffer id from the open function

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Flatten allows you to open files from a neovim terminal buffer in your current n
   - [x] Open in vsplit, split, tab, current window, or alternate window
 - [x] Pipe from terminal into a new Neovim buffer ([demo](https://user-images.githubusercontent.com/38540736/225779817-ed7efea8-9108-4f28-983f-1a889d32826f.mp4))
 - [x] Setting to force blocking from the commandline, regardless of filetype
-- [X] Command passthrough from guest to host
+- [x] Command passthrough from guest to host
 
 ## Plans and Ideas
 
@@ -123,8 +123,11 @@ Flatten comes with the following defaults:
         -- tab            -> open in new tab
         -- split          -> open in split
         -- vsplit         -> open in vsplit
-        -- func(new_bufs, argv) -> only open the files, allowing you to handle window opening yourself.
-        -- Argument is an array of buffer numbers representing the newly opened files.
+        -- func(new_file_names, argv, stdin_buf_id) -> only open the files, allowing you to handle window opening yourself.
+        -- The first argument is an array of file names representing the newly opened files.
+        -- The third argument is only provided when a buffer is created from stdin.
+        -- IMPORTANT: For `block_for` to work, you need to return a buffer number.
+        --            The `filetype` of this buffer will determine whether block should happen or not.
         open = "current",
         -- Affects which file gets focused when opening multiple at once
         -- Options:

--- a/lua/flatten/core.lua
+++ b/lua/flatten/core.lua
@@ -138,7 +138,6 @@ M.edit_files = function(opts)
 			end
 			name = newname
 		end
-		files[#files + 1] = name
 		vim.api.nvim_buf_set_name(stdin_buf, name)
 	end
 
@@ -147,13 +146,7 @@ M.edit_files = function(opts)
 
 	-- Open window
 	if type(open) == "function" then
-		-- Add buffer for stdin
-		local newbufs = {}
-		-- If there's an stdin buf, push it to the table
-		if stdin_buf then
-			table.insert(newbufs, stdin_buf)
-		end
-		bufnr = open(files, argv)
+		bufnr = open(files, argv, stdin_buf)
 		winnr = vim.fn.bufwinid(bufnr)
 	elseif type(open) == "string" then
 		local focus = vim.fn.argv(focus_first and 0 or (#files - 1))

--- a/lua/flatten/core.lua
+++ b/lua/flatten/core.lua
@@ -147,7 +147,9 @@ M.edit_files = function(opts)
 	-- Open window
 	if type(open) == "function" then
 		bufnr = open(files, argv, stdin_buf)
-		winnr = vim.fn.bufwinid(bufnr)
+		if bufnr ~= nil then
+			winnr = vim.fn.bufwinid(bufnr)
+		end
 	elseif type(open) == "string" then
 		local focus = vim.fn.argv(focus_first and 0 or (#files - 1))
 		-- If there's an stdin buf, focus that
@@ -174,7 +176,10 @@ M.edit_files = function(opts)
 		return false
 	end
 
-	local ft = vim.api.nvim_buf_get_option(bufnr, 'filetype')
+	local ft
+	if bufnr ~= nil then
+		ft = vim.api.nvim_buf_get_option(bufnr, 'filetype')
+	end
 
 	local block = config.block_for[ft] or force_block
 


### PR DESCRIPTION
The code to guess the list of added buffer ids was a bit hacky and didn't work all the time, it could return nvim-notify buffers, or not return the buffers that were already present in the buffer list for example. This code ran only when the open option was set to a lua function.

This PR tries to fix this issue by making the user return the buffer id as they have more context about how their `open` function handles the buffers.

For example most of the time I open terminals in floating windows, I have a custom `open` function which opens the buffer in the background main window like this:

```lua
          open = function(buffer_ids)
            local window_id = vim.api.nvim_tabpage_list_wins(0)[1]
            for _, buffer_id in ipairs(buffer_ids) do
              vim.api.nvim_win_set_buf(window_id, buffer_id)
            end
          end
```

It didn't work most of the time as `buffer_ids` were not correct and it also disabled `block_for` because `winnr` and `bufnr`  were incorrect in flatten's code resulting in an empty `ft` which was not detected as git. So most of the time `git commit` resulted in "Aborting commit due to empty commit message.".

Now after this PR I can change it to something like this:
```lua
          open = function(files)
            local window_id = vim.api.nvim_tabpage_list_wins(0)[1]
            local buffer_id
            for _, file in ipairs(files) do
              buffer_id = vim.fn.bufnr(file)
              vim.api.nvim_win_set_buf(window_id, buffer_id)
            end
            return buffer_id
          end
```

and everything works. In case the user's workflow involves opening buffers that `vim.fn.bufnr(file)` doesn't work for them, they know the context, the reason why it doesn't work, what's special about their buffers and can better handle it in their `open` function, I think it is a better approach than us trying to have a general solution in `flatten.core` to blindly predicting all the special buffer types/files different users may try to open with flatten.

P.S. I will add a commit to update the docs.