### PR TITLE
feat: smart open should prefer alternative window

### DIFF
--- a/lua/flatten/core.lua
+++ b/lua/flatten/core.lua
@@ -42,18 +42,24 @@ function M.smart_open(focus)
 
   -- traverse the window tree to find the first available window
   local stack = { layout }
+  local win_alt = vim.fn.win_getid(vim.fn.winnr("#"))
   local win
 
-  while #stack > 0 do
-    local node = table.remove(stack)
-    if node[1] == "leaf" then
-      if valid_targets[node[2]] then
-        win = node[2]
-        break
-      end
-    else
-      for i = #node[2], 1, -1 do
-        table.insert(stack, node[2][i])
+  -- prefer the alternative window if it's valid
+  if valid_targets[win_alt] and win_alt ~= vim.api.nvim_get_current_win() then
+    win = win_alt
+  else
+    while #stack > 0 do
+      local node = table.remove(stack)
+      if node[1] == "leaf" then
+        if valid_targets[node[2]] then
+          win = node[2]
+          break
+        end
+      else
+        for i = #node[2], 1, -1 do
+          table.insert(stack, node[2][i])
+        end
       end
     end
   end


### PR DESCRIPTION
Currently smart open will pick the FIRST window that is "valid" (a window that is not floating and contains a normal buffer, etc.), which can be unintuitive sometimes.

Suppose I have the following window layout and my cursor is at window `B`, and in `C` runs ranger in a terminal:

```
+-------------------+
|    A    |    B    |
|         |         |
|-------------------|
|    C (terminal)   |
|                   |
+-------------------+
```

If I switch from `B` to `C` using `<C-w>j`, then open a file from ranger, the current implementation of smart open will open the file in `A`, but I expect it to be opened in `B`.

This PR fixes this issue by picking the alternative window (`B`) if it is valid.
