### PR TITLE
fix: handle absolute paths on windows

### DIFF
--- a/lua/flatten/core.lua
+++ b/lua/flatten/core.lua
@@ -141,7 +141,13 @@ function M.edit_files(opts)
   -- Open files
   if nfiles > 0 then
     for i, fname in ipairs(files) do
-      local is_absolute = string.find(fname, "^/")
+      local is_absolute = false
+      if vim.fn.has("win32") then
+        is_absolute = string.find(fname, "^%a:") ~= nil
+      else
+        is_absolute = string.find(fname, "^/") ~= nil
+      end
+
       local fpath = is_absolute and fname or (guest_cwd .. "/" .. fname)
       local file = {
         fname = fpath,


### PR DESCRIPTION
Hello, absolute paths on windows weren't being identified.
Aside from that, everything works flawlessly on windows. Amazing plugin, thank you ✨