### PR TITLE
fix: returned truthy of vim.fn

### DIFF
--- a/lua/flatten/core.lua
+++ b/lua/flatten/core.lua
@@ -142,7 +142,7 @@ function M.edit_files(opts)
   if nfiles > 0 then
     for i, fname in ipairs(files) do
       local is_absolute = false
-      if vim.fn.has("win32") then
+      if vim.fn.has("win32") == 1 then
         is_absolute = string.find(fname, "^%a:") ~= nil
       else
         is_absolute = string.find(fname, "^/") ~= nil


### PR DESCRIPTION
In Lua, integer value is always recognized as `true`. So we should check if a returned value from `vim.fn.has("win32")` is 1 or not.