### PR TITLE
fix: `timeout must be >= 0` for vim.wait

### DIFF
--- a/lua/flatten/guest.lua
+++ b/lua/flatten/guest.lua
@@ -22,7 +22,7 @@ function M.maybe_block(block)
     vim.cmd.qa({ bang = true })
   end
   waiting = true
-  local res, ctx = vim.wait(0xFFFFFFFFFFFFFFFF, function()
+  local res, ctx = vim.wait(0X7FFFFFFF, function()
     return waiting == false
       or vim.api.nvim_get_chan_info(host) == vim.empty_dict()
   end, 200, false)


### PR DESCRIPTION
Crash on my system:
```
Error detected while processing BufEnter Autocommands for "*":
Error executing lua callback: ...local/share/nvim/lazy/flatten.nvim/lua/flatten/guest.lua:26: timeout must be >= 0
```

Not sure if lua have the conception of largest integer, but I think `0X7FFFFFFF` should work for most machine (e.g. 32 bits).
