### PR TITLE
Fix URL recognition

### DIFF
--- a/lua/flatten/core.lua
+++ b/lua/flatten/core.lua
@@ -1,7 +1,9 @@
 local M = {}
 
 local function path_is_absolute(path)
-  path = string.gsub(path, "^%s+://", "")
+  if string.find(path, "^%a[%w.+-]*://") then
+    return true
+  end
 
   if jit.os == "Windows" then
     return string.find(path, "^%a:") ~= nil


### PR DESCRIPTION
This PR fixes the pattern used to recognize and strip URL schemes so that paths starting with `oil://`, `oil-ssh://` and alike are recognized.

~~Also I can't think of an example where a URL starting with a scheme is relative, so I treated them all as absolute ones. This fixes the (newly emerged) problem with `oil-ssh` where it's like `oil-ssh://user@host/path`.~~

Well `oil://...` URLs do work like that. Idk if people use it like that instead of just sending the directory though. Any further ideas are welcome.