### PR TITLE
feat(config): pre_open can return updated config

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,8 +229,9 @@ Defaults are in `flatten.hooks`.
     This is useful for customizing when files should be sent to a host instance and when they should be opened
     in a new one.
 
-- `hooks.pre_open`: `fun(opts: Flatten.PreOpenContext)`
+- `hooks.pre_open`: `fun(opts: Flatten.PreOpenContext): Flatten.Config?`
   - Called before opening files.
+  - Returned config, if any, will be merged with the global config (for this file only).
 
   - `Flatten.PreOpenContext`:
     - `data`: `any`

--- a/lua/flatten/init.lua
+++ b/lua/flatten/init.lua
@@ -124,7 +124,8 @@ local Flatten = {}
 ---config.nest_if_no_args is respected.
 ---@field should_nest? fun(host: integer):boolean
 ---Called before a nested session is opened.
----@field pre_open? fun(opts: Flatten.PreOpenContext)
+---Retuened config is merged with global config for this file
+---@field pre_open? fun(opts: Flatten.PreOpenContext): Flatten.Config?
 ---Called after a nested session is opened.
 ---@field post_open? fun(opts: Flatten.PostOpenContext)
 ---Called when a nested session is done waiting for the host.


### PR DESCRIPTION
The `pre_open` hook can now return a table which will be merged with the
user's default config for the current file being edited.

This allows per file name/type configuration provided appropriate data
is passed via the `guest_data` hook.

If `pre_open` returns `nil`, behaviour is unchanged.


Closes #111 
