### PR TITLE
fix: parse_argv error with nest_if_no_args=true. Closes #108

### DIFF
--- a/lua/flatten/core.lua
+++ b/lua/flatten/core.lua
@@ -52,7 +52,7 @@ end
 
 ---@param argv string[]
 ---@return string[] pre_cmds, string[] post_cmds
-local function parse_argv(argv)
+function M.parse_argv(argv)
   local pre_cmds, post_cmds = {}, {}
   local is_cmd = false
   for _, arg in ipairs(argv) do
@@ -76,7 +76,7 @@ end
 function M.run_commands(opts)
   local argv = opts.argv
 
-  local pre_cmds, post_cmds = parse_argv(argv)
+  local pre_cmds, post_cmds = M.parse_argv(argv)
 
   for _, cmd in ipairs(pre_cmds) do
     vim.api.nvim_exec2(cmd, {})
@@ -152,7 +152,7 @@ function M.edit_files(opts)
   local stdin_lines = #stdin
 
   --- commands passed through with +<cmd>, to be executed after opening files
-  local pre_cmds, post_cmds = parse_argv(argv)
+  local pre_cmds, post_cmds = M.parse_argv(argv)
 
   if
     nfiles == 0


### PR DESCRIPTION
Fix #108.

`require("flatten.core").parse_argv` not exists:

https://github.com/willothy/flatten.nvim/blob/b17a3e65c2e4e2ecd1345a2d08435e80f982c4a6/lua/flatten/init.lua#L221-L221

Related to this [commit](https://github.com/willothy/flatten.nvim/commit/7605dec006bd91f2ffafd9fac74f6b6b773333a4).