### PR TITLE
fix(core)!: changed the order expected from open

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ local config = {
     - A custom function that returns a window number and optionally a buffer.
 
   - `Flatten.OpenContext`:
-    - `files`: `string[]`
+    - `files`: `Flatten.BufInfo[]`
       - The list of files passed to the host.
     - `argv`: `string[]`
       - The full argv list from the *guest* instance.

--- a/lua/flatten/core.lua
+++ b/lua/flatten/core.lua
@@ -279,7 +279,7 @@ function M.edit_files(opts)
     winnr = winnr or vim.api.nvim_get_current_win()
     bufnr = bufnr or vim.api.nvim_get_current_buf()
   elseif type(open) == "function" then
-    bufnr, winnr = open({
+    winnr, bufnr = open({
       files = files,
       argv = argv,
       stdin_buf = stdin_buf,


### PR DESCRIPTION
This is inline with documentation and the way `diff` expects it's return
values.

This is a breaking change, however, I think it will mostly affect hooks,
not the core functionality. Namely this will change the value passed for
`winnr` to `post_open` and may cause `block_end` to not be called.

This also only people who were using `open` as a function, rather than a
string, and have already swapped the two values.

Also updated type of `files` in README. This is not a breaking change as using the argument as a `string[]` will have resulted in an error.