### PR TITLE
fix: open file with swap error

### DIFF
--- a/lua/flatten/core.lua
+++ b/lua/flatten/core.lua
@@ -184,9 +184,14 @@ function M.edit_files(opts)
         fpath = guest_cwd .. "/" .. fname
       end
 
+      local bufnr = vim.fn.bufadd(fpath)
+      -- Disable swapfile before loading to avoid interactive prompts
+      vim.api.nvim_set_option_value("swapfile", false, { buf = bufnr })
+      vim.fn.bufload(bufnr)
+
       local file = {
         fname = fpath,
-        bufnr = vim.fn.bufadd(fpath),
+        bufnr = bufnr,
       }
 
       vim.api.nvim_set_option_value("buflisted", true, {


### PR DESCRIPTION
Similar to the existing issues:
https://github.com/willothy/flatten.nvim/issues/116
https://github.com/willothy/flatten.nvim/pull/109

The core problem is that opening a file that already has a swap file triggers an interactive prompt:
```plaintext
Swap file found!
[O] Read-only, (E)dit anyway, (R)ecover, (Q)uit
```
However, when opening from the terminal, the interactive prompt cannot be handled.

The current workaround is to open the file without checking the swap file.